### PR TITLE
Added command for iOS pod install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ``` bash
 # Install dependencies
 npm install
+cd ios && pod install && cd ..
 
 # Run on iOS
 react-native run-ios


### PR DESCRIPTION
React Native apps will fail to compile and emulate properly without Apple's precious pods.