### PR TITLE
Added iOS pod install instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ``` bash
 # Install dependencies
 npm install
+cd ios && pod install && cd ..
 
 # Run on iOS
 react-native run-ios


### PR DESCRIPTION
Pod installation is needed for the app to successfully compile and emulate for iOS on Mac OS